### PR TITLE
Add capacity component

### DIFF
--- a/src/components/design/mixin/render/rect-nav.js
+++ b/src/components/design/mixin/render/rect-nav.js
@@ -5,9 +5,17 @@ let {
   span,
   div
 } = jsx
+// vIcon 用于显示组件图标
+let vIcon = jsx.bind('v-icon')
 let _renderRectNav = function () {
   let me = this
-  let retTags = ['rect', 'circle', 'text', 'line'].map(type => {
+  // 新增可创建的组件类型 "capacity"
+  let retTags = ['rect', 'circle', 'text', 'line', 'capacity'].map(type => {
+    let children = [rectConfig[type].name]
+    // capacity 组件使用圆形图标
+    if (type === 'capacity') {
+      children = [vIcon({props_name: 'circle'})]
+    }
     return span({
       'class_label': true,
       on_mousedown (e) {
@@ -16,7 +24,7 @@ let _renderRectNav = function () {
         me.mouse.createType = type
         event.$emit('windowMouseDown', e)
       },
-    }, rectConfig[type].name)
+    }, ...children)
   })
   return div({
     'class_proto-rect-tags': true,

--- a/src/components/design/mixin/render/setting.js
+++ b/src/components/design/mixin/render/setting.js
@@ -355,6 +355,16 @@ let _renderSetting = function () {
       )
       children = [...children, $fontAlignY]
     }
+    // 当为产能组件时，显示额外的产能字段
+    if (rect.type === 'rect-capacity') {
+      let $capacity = div({'class_proto-setting-box-item': true},
+        span('产能'),
+        input({
+          ...getInputJsxProps('capacity'),
+        })
+      )
+      children = [...children, $capacity]
+    }
     let $opacity = div({'class_proto-setting-box-item': true},
       span('不透明度'),
       input({

--- a/src/core/rect-config.js
+++ b/src/core/rect-config.js
@@ -42,6 +42,13 @@ let circle = {
   borderRadius: '100%',
   width: 100,
 }
+// 产能组件，基于圆形并新增 "capacity" 字段
+let capacity = {
+  ...circle,
+  name: '产能',
+  // 产能数值，默认空字符串
+  capacity: '',
+}
 let group = {
   ...base,
   name: '群组'
@@ -75,4 +82,5 @@ export {
   group,
   tempGroup,
   line,
+  capacity,
 }


### PR DESCRIPTION
## Summary
- create new capacity rect type with circular icon
- list the capacity component in rectangle nav
- allow entering "产能" value in style panel

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865dff3ea1c832280d0b6427ffe090c