### PR TITLE
新增流程控件

### DIFF
--- a/src/components/design/mixin/render/rect-nav.js
+++ b/src/components/design/mixin/render/rect-nav.js
@@ -9,12 +9,16 @@ let {
 let vIcon = jsx.bind('v-icon')
 let _renderRectNav = function () {
   let me = this
-  // 新增可创建的组件类型 "capacity"
-  let retTags = ['rect', 'circle', 'text', 'line', 'capacity'].map(type => {
+  // 只保留流程组件
+  let retTags = ['process'].map(type => {
     let children = [rectConfig[type].name]
-    // capacity 组件使用圆形图标
-    if (type === 'capacity') {
-      children = [vIcon({props_name: 'circle'})]
+    // 使用图片作为图标
+    if (type === 'process') {
+      children = [jsx.bind('img')({
+        attrs_src: rectConfig[type].src,
+        style_width: '16px',
+        style_height: '16px',
+      })]
     }
     return span({
       'class_label': true,

--- a/src/components/design/mixin/render/rect.js
+++ b/src/components/design/mixin/render/rect.js
@@ -57,6 +57,13 @@ let _renderRect = function (rect) {
   let children = []
   if (!this._checkIsGroupLike(rect)){
     jsxProps['on_dblclick'] = (e) => {
+      // 流程组件双击弹出对话框
+      if (rectType === 'rect-process') {
+        me._focusRect(rect, {shiftKey: e.shiftKey})
+        me.$processDialog()
+        mouse.ing = false
+        return
+      }
       me._focusRect(rect, e)
       mouse.ing = false
     }
@@ -79,6 +86,7 @@ let _renderRectInner = function (rect) {
   let isEdit = rect.data.isEdit
   let data = rect.data
   let isLine = rect.type === 'rect-line'
+  let isProcess = rect.type === 'rect-process'
   let jsxProps = {
     'class_proto-rect-inner': true,
   }
@@ -91,7 +99,7 @@ let _renderRectInner = function (rect) {
       'style_border-top-color': data.borderColor,
     }
   }
-  else {
+  else if (!isProcess) {
     jsxProps = {
       ...jsxProps,
       'style_border-width': data.borderWidth + 'px',
@@ -150,7 +158,13 @@ let _renderRectInner = function (rect) {
     }
     children = [span(textJsxProps)]
   }
-  
+  if (isProcess) {
+    children = [jsx.bind('img')({
+      attrs_src: data.src,
+      style_width: '100%',
+      style_height: '100%',
+    })]
+  }
   return div(jsxProps, ...children)
 }
 let _renderRects = function () {

--- a/src/components/design/mixin/render/setting.js
+++ b/src/components/design/mixin/render/setting.js
@@ -187,6 +187,24 @@ let _renderSetting = function () {
       )
       children = [...children, $angle]
     }
+    // 流程组件仅显示基础属性
+    if (rect.type === 'rect-process') {
+      children = [$left, $top, $width, $height]
+      if (!isTempGroup) {
+        children.push($angle)
+      }
+      return div({
+        'class_card': true,
+        ...jsxProps,
+      },
+        div('.card-header',
+          div('.card-title h6', '样式'),
+        ),
+        div('.card-body',
+          ...children,
+        )
+      )
+    }
     if (!isLine){
       let $isSameRatio = div({'class_proto-setting-box-item': true},
         span('等比缩放'),

--- a/src/components/process-dialog.vue
+++ b/src/components/process-dialog.vue
@@ -1,0 +1,91 @@
+<style lang="scss">
+.process-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.process-dialog {
+  background: #fff;
+  width: 400px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+.process-dialog-tabs {
+  display: flex;
+  border-bottom: 1px solid #ccc;
+}
+.process-dialog-tab {
+  flex: 1;
+  text-align: center;
+  padding: 8px 0;
+  cursor: pointer;
+}
+.process-dialog-tab-active {
+  font-weight: bold;
+}
+.process-dialog-content {
+  min-height: 150px;
+  padding: 10px;
+}
+</style>
+<script>
+import Vue from 'vue'
+import jsx from 'vue-jsx'
+let { div } = jsx
+let ProcessDialog = {
+  name: 'ProcessDialog',
+  data () {
+    return {
+      isOpen: false,
+      currTab: '产品',
+    }
+  },
+  methods: {
+    open () { this.isOpen = true },
+    close () { this.isOpen = false },
+    switchTab (tab) { this.currTab = tab },
+  },
+  render (h) {
+    jsx.h = h
+    if (!this.isOpen) {
+      return null
+    }
+    let me = this
+    let tab = (name) => div({
+      'class_process-dialog-tab': true,
+      'class_process-dialog-tab-active': me.currTab === name,
+      on_click () { me.switchTab(name) },
+    }, name)
+    return div('.process-dialog-overlay', {
+      on_click () { me.close() },
+    },
+      div('.process-dialog', {
+        on_click (e) { e.stopPropagation() },
+      },
+        div('.process-dialog-tabs',
+          tab('产品'),
+          tab('流程设置'),
+        ),
+        div('.process-dialog-content')
+      )
+    )
+  }
+}
+let globalDialog
+Vue.prototype.$processDialog = () => {
+  if (!globalDialog) {
+    let Ctor = Vue.extend(ProcessDialog)
+    globalDialog = new Ctor
+    globalDialog.$mount(document.createElement('div'))
+    document.body.appendChild(globalDialog.$el)
+  }
+  globalDialog.open()
+}
+export default ProcessDialog
+</script>

--- a/src/core/rect-config.js
+++ b/src/core/rect-config.js
@@ -49,6 +49,16 @@ let capacity = {
   // 产能数值，默认空字符串
   capacity: '',
 }
+// 流程组件，显示固定图片
+let process = {
+  ...rect,
+  name: '流程',
+  // 图片地址，默认指向 res 目录
+  src: '/res/process.emf',
+  text: '',
+  borderWidth: 0,
+  backgroundColor: 'transparent',
+}
 let group = {
   ...base,
   name: '群组'
@@ -83,4 +93,5 @@ export {
   tempGroup,
   line,
   capacity,
+  process,
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import Spectre from '@/components/spectre/index'
 import 'vue-awesome/icons'
 import Icon from 'vue-awesome/components/Icon'
 import Design from '@/components/design/index'
+import '@/components/process-dialog.vue'
 Vue.use(Spectre)
 Vue.use(VueRouter)
 Vue.component('v-icon', Icon)


### PR DESCRIPTION
## Summary
- 添加流程控件的配置及导航
- 双击流程控件弹出带有"产品"和"流程设置"选项卡的对话框
- 样式面板针对流程控件仅保留基础属性
- 引入全局对话框组件

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674b72dc48832298d936d805ba5848