### PR TITLE
Add process component

### DIFF
--- a/src/components/design/mixin/render/rect-nav.js
+++ b/src/components/design/mixin/render/rect-nav.js
@@ -9,12 +9,19 @@ let {
 let vIcon = jsx.bind('v-icon')
 let _renderRectNav = function () {
   let me = this
-  // 新增可创建的组件类型 "capacity"
-  let retTags = ['rect', 'circle', 'text', 'line', 'capacity'].map(type => {
+  // 可创建的组件列表，新增 "process" 类型
+  let retTags = ['rect', 'circle', 'text', 'line', 'capacity', 'process'].map(type => {
     let children = [rectConfig[type].name]
     // capacity 组件使用圆形图标
     if (type === 'capacity') {
       children = [vIcon({props_name: 'circle'})]
+    }
+    // process 组件使用图片作为图标
+    if (type === 'process') {
+      children = [jsx.create('img', {
+        attrs_src: rectConfig[type].img,
+        style_width: '20px',
+      })]
     }
     return span({
       'class_label': true,

--- a/src/components/design/mixin/render/rect.js
+++ b/src/components/design/mixin/render/rect.js
@@ -5,6 +5,8 @@ import {
   isRightMouse,
 } from "@/core/base"
 import event from '@/core/event'
+// 流程控件所使用的图像
+import processImg from '@/../res/process.png'
 let { div, span } = jsx
 let _renderRect = function (rect) {
   let me = this
@@ -57,6 +59,15 @@ let _renderRect = function (rect) {
   let children = []
   if (!this._checkIsGroupLike(rect)){
     jsxProps['on_dblclick'] = (e) => {
+      // 如果是流程控件，则弹出流程对话框
+      if (rect.type === 'rect-process') {
+        me._focusRect(rect, e)
+        rect.data.isEdit = false
+        me.$processDialog()
+        mouse.ing = false
+        return
+      }
+      // 其它控件保持原来的双击编辑逻辑
       me._focusRect(rect, e)
       mouse.ing = false
     }
@@ -97,7 +108,12 @@ let _renderRectInner = function (rect) {
       'style_border-width': data.borderWidth + 'px',
       'style_border-style': data.borderStyle,
       'style_border-color': data.borderColor,
-      'style_background-color': data.backgroundColor,
+      // 对于流程控件，使用图片作为背景
+      ...(rect.type === 'rect-process' ? {
+        style_background: `url(${processImg}) center/contain no-repeat`
+      } : {
+        'style_background-color': data.backgroundColor,
+      }),
       'style_border-radius': percentPx(data.borderRadius),
       'style_align-items': data.textAlignY,
       'style_justify-content': data.textAlignX,
@@ -110,7 +126,11 @@ let _renderRectInner = function (rect) {
       'style_font-size': data.fontSize + 'px',
       'style_font-family': data.fontFamily,
     }
-    if (isEdit) {
+    // 流程控件不显示文本
+    if (rect.type === 'rect-process') {
+      textJsxProps = null
+    }
+    if (isEdit && textJsxProps) {
       textJsxProps = {
         ...textJsxProps,
         style_cursor: 'text',
@@ -142,13 +162,15 @@ let _renderRectInner = function (rect) {
         }
       })
     }
-    else {
+    else if (textJsxProps) {
       textJsxProps = {
         ...textJsxProps,
         'domProps_innerHTML': data.text,
       }
     }
-    children = [span(textJsxProps)]
+    if (textJsxProps) {
+      children = [span(textJsxProps)]
+    }
   }
   
   return div(jsxProps, ...children)

--- a/src/components/design/mixin/render/setting.js
+++ b/src/components/design/mixin/render/setting.js
@@ -18,11 +18,11 @@ let _renderSetting = function () {
   let rect = this._safeObject(
     this.currRectId || this._getSelectedRects()[0]
   )
-  let children = []
+    let children = []
 
-  if (rect){
-    let rectData = rect.data
-    let isGroupLike = this._checkIsGroupLike(rect)
+    if (rect){
+      let rectData = rect.data
+      let isGroupLike = this._checkIsGroupLike(rect)
     let isTempGroup = this._checkIsTempGroup(rect)
     let isLine = rect.type === 'rect-line'
     let isText = rect.type === 'rect-text'
@@ -71,6 +71,50 @@ let _renderSetting = function () {
         }
       }
       return jsxProps
+    }
+    if (rect.type === 'rect-process') {
+      // 流程控件仅展示坐标、尺寸和角度设置
+      const fields = ['left','top','width','height','angle']
+      fields.forEach(prop => {
+        let label = {
+          left: 'X轴坐标',
+          top: 'Y轴坐标',
+          width: '宽度',
+          height: '高度',
+          angle: '角度'
+        }[prop]
+        let inputItem = div({'class_proto-setting-box-item': true},
+          span(label),
+          input({
+            ...getInputJsxProps(prop),
+            on_change: (e) => {
+              let v = parseInt(e.target.value)
+              if (prop === 'left') { me._moveLeftTo(rect, v) }
+              if (prop === 'top') { me._moveTopTo(rect, v) }
+              if (prop === 'width') { me._resizeWidthTo(rect, Math.max(10,v)) }
+              if (prop === 'height') { me._resizeHeightTo(rect, Math.max(10,v)) }
+              if (prop === 'angle') {
+                v = v % 360
+                if (v < 0) v += 360
+                me._rotateTo(rect, v)
+              }
+              me._historyPush()
+            }
+          })
+        )
+        children = [...children, inputItem]
+      })
+      return div({
+        'class_card': true,
+        ...jsxProps,
+      },
+        div('.card-header',
+          div('.card-title h6', '样式'),
+        ),
+        div('.card-body',
+          ...children,
+        )
+      )
     }
     if (isTempGroup){
       let $align = div({'class_proto-setting-box-item': true},

--- a/src/components/process-dialog.vue
+++ b/src/components/process-dialog.vue
@@ -1,0 +1,97 @@
+<style scoped lang="scss">
+.process-dialog-mask {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.process-dialog {
+  width: 400px;
+}
+.process-dialog .tab {
+  display: flex;
+}
+.process-dialog .tab a {
+  flex: 1;
+  text-align: center;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+.process-dialog .tab a.active {
+  font-weight: bold;
+  border-bottom: 2px solid #666;
+}
+</style>
+<script>
+import Vue from 'vue'
+import jsx from 'vue-jsx'
+let { div, a } = jsx
+const ProcessDialog = {
+  name: 'ProcessDialog',
+  data () {
+    return {
+      isOpen: false,
+      currTab: 0,
+    }
+  },
+  methods: {
+    open () {
+      this.isOpen = true
+    },
+    close () {
+      this.isOpen = false
+    },
+    _renderTabs () {
+      let me = this
+      let tabProps = index => ({
+        'class_tab-item': true,
+        'class_active': this.currTab === index,
+        on_click () { me.currTab = index }
+      })
+      return div('.tab tab-block',
+        a(tabProps(0), '产品'),
+        a(tabProps(1), '流程设置')
+      )
+    },
+    _renderMain () {
+      let me = this
+      if (!this.isOpen) { return null }
+      return div('.process-dialog-mask',
+        {
+          on_click () { me.close() }
+        },
+        div('.process-dialog card',
+          {
+            on_click (e) { e.stopPropagation() }
+          },
+          div('.card-header', this._renderTabs()),
+          div('.card-body',
+            this.currTab === 0 ? div('') : div('')
+          )
+        )
+      )
+    }
+  },
+  render (h) {
+    jsx.h = h
+    return this._renderMain()
+  }
+}
+let globalDialog
+Vue.prototype.$processDialog = function () {
+  if (!globalDialog) {
+    let Ctor = Vue.extend(ProcessDialog)
+    globalDialog = new Ctor
+    globalDialog.$mount(document.createElement('div'))
+    document.body.appendChild(globalDialog.$el)
+  }
+  globalDialog.open()
+}
+export default ProcessDialog
+</script>

--- a/src/core/rect-config.js
+++ b/src/core/rect-config.js
@@ -49,6 +49,14 @@ let capacity = {
   // 产能数值，默认空字符串
   capacity: '',
 }
+// 流程组件，使用图片进行展示
+let process = {
+  ...rect,
+  name: '流程',
+  // 记录图片路径，渲染时作为背景
+  img: require('../res/process.png'),
+  text: '',
+}
 let group = {
   ...base,
   name: '群组'
@@ -83,4 +91,5 @@ export {
   tempGroup,
   line,
   capacity,
+  process,
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,8 @@ import Spectre from '@/components/spectre/index'
 import 'vue-awesome/icons'
 import Icon from 'vue-awesome/components/Icon'
 import Design from '@/components/design/index'
+// 引入流程对话框组件，使其在全局原型上注册
+import '@/components/process-dialog'
 Vue.use(Spectre)
 Vue.use(VueRouter)
 Vue.component('v-icon', Icon)


### PR DESCRIPTION
## Summary
- add `process` element config referencing `res/process.png`
- show new icon in element list
- open a blank dialog with tabs when double-clicking a process element
- only show position/size/angle settings for process elements
- add dialog component and register via main.js

## Testing
- `npm run build` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867502e5a88832290172fe9f65f357b