### PR TITLE
新增多图片组件

### DIFF
--- a/src/components/design/mixin/render/rect-nav.js
+++ b/src/components/design/mixin/render/rect-nav.js
@@ -1,19 +1,27 @@
 // import * as rectConfig from '@/core/rect-config'
 import jsx from 'vue-jsx'
 import event from '@/core/event'
-// 引入流程控件图片
-import processImg from '@/../res/process.png'
+// 左侧导航只展示图片型组件，可拖拽创建对应流程控件
 let {
   span,
   div
 } = jsx
 let _renderRectNav = function () {
   let me = this
-  // 仅保留流程控件
-  let retTags = ['process'].map(type => {
-    // 控件图标使用流程图片
+  // 根据图片名称映射图片资源，键名即组件类型
+  // require 语句在构建时会被 webpack 处理为图片 URL
+  let images = {
+    process: require('@/../res/process.png'),
+    PPS: require('@/../res/PPS.png'),
+    connector: require('@/../res/connector.png'),
+    customer: require('@/../res/customer.png'),
+    fifo: require('@/../res/fifo.png'),
+    stock: require('@/../res/stock.png'),
+  }
+  let retTags = Object.keys(images).map(type => {
     let img = jsx.bind('img')
-    let children = [img({attrs_src: processImg, style_width: '24px', style_height: '24px'})]
+    // 使用对应图片作为控件图标
+    let children = [img({ attrs_src: images[type], style_width: '24px', style_height: '24px' })]
     return span({
       'class_label': true,
       on_mousedown (e) {

--- a/src/components/design/mixin/render/rect.js
+++ b/src/components/design/mixin/render/rect.js
@@ -5,6 +5,16 @@ import {
   isRightMouse,
 } from "@/core/base"
 import event from '@/core/event'
+// 流程图使用的图片资源映射表
+// 通过 require 获取图片 URL，便于 webpack 在打包时处理
+const imageTypes = {
+  process: require('@/../res/process.png'),
+  PPS: require('@/../res/PPS.png'),
+  connector: require('@/../res/connector.png'),
+  customer: require('@/../res/customer.png'),
+  fifo: require('@/../res/fifo.png'),
+  stock: require('@/../res/stock.png'),
+}
 let { div, span } = jsx
 let _renderRect = function (rect) {
   let me = this
@@ -60,8 +70,9 @@ let _renderRect = function (rect) {
     jsxProps['on_dblclick'] = (e) => {
       me._focusRect(rect, e)
       mouse.ing = false
-      // 双击流程控件时弹出流程配置对话框
-      if (rect.type === 'rect-process') {
+      // 双击图片型组件时弹出流程配置对话框
+      let typeKey = rect.type.replace('rect-', '')
+      if (typeKey in imageTypes) {
         me.$processDialog()
         return
       }
@@ -116,11 +127,11 @@ let _renderRectInner = function (rect) {
       'style_font-size': data.fontSize + 'px',
       'style_font-family': data.fontFamily,
     }
-    // 流程控件使用图片渲染
-    if (rect.type === 'rect-process') {
+    // 图片型组件统一使用对应图片渲染
+    let typeKey = rect.type.replace('rect-', '')
+    if (typeKey in imageTypes) {
       let img = jsx.bind('img')
-      children = [img({attrs_src: require('@/../res/process.png'),
-        style_width: '100%', style_height: '100%'})]
+      children = [img({ attrs_src: imageTypes[typeKey], style_width: '100%', style_height: '100%' })]
       return div(jsxProps, ...children)
     }
     if (isEdit) {

--- a/src/components/design/mixin/render/setting.js
+++ b/src/components/design/mixin/render/setting.js
@@ -271,8 +271,11 @@ let _renderSetting = function () {
               let intValue = Math.max(0, parseInt(value))
               rect.data.borderWidth = intValue
               if (isLine){
+                // 线条宽度即高度
                 rect.data.height = intValue
               }
+              // 更新历史记录触发重渲染
+              me._historyPush()
             }
           })
         )
@@ -352,6 +355,8 @@ let _renderSetting = function () {
             if (rectData.isAutoSize) {
               me._resizeText(rect)
             }
+            // 记录历史并刷新
+            me._historyPush()
           },
         })
       )

--- a/src/core/rect-config.js
+++ b/src/core/rect-config.js
@@ -50,10 +50,20 @@ let capacity = {
   capacity: '',
 }
 // 流程控件，使用图片作为元素图
+// 流程控件，默认以图片实际尺寸创建，并去除边框
 let process = {
   ...rect,
   name: '流程',
+  width: 156,
+  height: 99,
+  borderWidth: 0,
 }
+// 以下组件与流程组件除名称外完全一致，仅名称及尺寸不同
+let PPS = { ...process, name: 'PPS', width: 174, height: 98 }
+let connector = { ...process, name: 'connector', width: 155, height: 37 }
+let customer = { ...process, name: 'customer', width: 174, height: 117 }
+let fifo = { ...process, name: 'fifo', width: 100, height: 25 }
+let stock = { ...process, name: 'stock', width: 80, height: 75 }
 let group = {
   ...base,
   name: '群组'
@@ -89,4 +99,9 @@ export {
   line,
   capacity,
   process,
+  PPS,
+  connector,
+  customer,
+  fifo,
+  stock,
 }


### PR DESCRIPTION
## Summary
- 扩展 `rect-config`，为 `res` 目录下所有图片新增组件配置
- 重构 `rect-nav`，自动读取图片生成组件图标
- 更新 `rect` 渲染逻辑，统一处理图片型组件
- 修复设置面板边框宽度与文本大小修改无效的问题
- 图片组件默认以原图尺寸创建，且无边框

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686770e76cec8322a5e5600f26b2d6f4