### PR TITLE
Add components from res images

### DIFF
--- a/src/components/design/mixin/render/rect-nav.js
+++ b/src/components/design/mixin/render/rect-nav.js
@@ -3,17 +3,30 @@ import jsx from 'vue-jsx'
 import event from '@/core/event'
 // 引入流程控件图片
 import processImg from '@/../res/process.png'
+import ppsImg from '@/../res/PPS.png'
+import connectorImg from '@/../res/connector.png'
+import customerImg from '@/../res/customer.png'
+import fifoImg from '@/../res/fifo.png'
+import stockImg from '@/../res/stock.png'
 let {
   span,
   div
 } = jsx
 let _renderRectNav = function () {
   let me = this
-  // 仅保留流程控件
-  let retTags = ['process'].map(type => {
-    // 控件图标使用流程图片
+  // 可创建的流程类控件列表
+  let imgMap = {
+    process: processImg,
+    pps: ppsImg,
+    connector: connectorImg,
+    customer: customerImg,
+    fifo: fifoImg,
+    stock: stockImg,
+  }
+  let retTags = Object.keys(imgMap).map(type => {
     let img = jsx.bind('img')
-    let children = [img({attrs_src: processImg, style_width: '24px', style_height: '24px'})]
+    // 每个图标对应不同图片
+    let children = [img({ attrs_src: imgMap[type], style_width: '24px', style_height: '24px' })]
     return span({
       'class_label': true,
       on_mousedown (e) {

--- a/src/components/design/mixin/render/rect.js
+++ b/src/components/design/mixin/render/rect.js
@@ -5,6 +5,15 @@ import {
   isRightMouse,
 } from "@/core/base"
 import event from '@/core/event'
+// 图片映射表，用于渲染流程类控件
+const processImgMap = {
+  'rect-process': require('@/../res/process.png'),
+  'rect-pps': require('@/../res/PPS.png'),
+  'rect-connector': require('@/../res/connector.png'),
+  'rect-customer': require('@/../res/customer.png'),
+  'rect-fifo': require('@/../res/fifo.png'),
+  'rect-stock': require('@/../res/stock.png'),
+}
 let { div, span } = jsx
 let _renderRect = function (rect) {
   let me = this
@@ -60,8 +69,8 @@ let _renderRect = function (rect) {
     jsxProps['on_dblclick'] = (e) => {
       me._focusRect(rect, e)
       mouse.ing = false
-      // 双击流程控件时弹出流程配置对话框
-      if (rect.type === 'rect-process') {
+      // 双击流程相关控件时弹出配置对话框
+      if (rect.type in processImgMap) {
         me.$processDialog()
         return
       }
@@ -116,11 +125,14 @@ let _renderRectInner = function (rect) {
       'style_font-size': data.fontSize + 'px',
       'style_font-family': data.fontFamily,
     }
-    // 流程控件使用图片渲染
-    if (rect.type === 'rect-process') {
+    // 流程类控件使用图片渲染
+    if (rect.type in processImgMap) {
       let img = jsx.bind('img')
-      children = [img({attrs_src: require('@/../res/process.png'),
-        style_width: '100%', style_height: '100%'})]
+      children = [img({
+        attrs_src: processImgMap[rect.type],
+        style_width: '100%',
+        style_height: '100%'
+      })]
       return div(jsxProps, ...children)
     }
     if (isEdit) {

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -1,2 +1,3 @@
 import Vue from 'vue'
-export default new Vue
+// 事件总线，用于跨组件通信
+export default new Vue()

--- a/src/core/rect-config.js
+++ b/src/core/rect-config.js
@@ -54,6 +54,31 @@ let process = {
   ...rect,
   name: '流程',
 }
+// PPS 控件，与流程控件属性一致，仅修改名称
+let pps = {
+  ...rect,
+  name: 'PPS',
+}
+// connector 控件
+let connector = {
+  ...rect,
+  name: 'connector',
+}
+// customer 控件
+let customer = {
+  ...rect,
+  name: 'customer',
+}
+// fifo 控件
+let fifo = {
+  ...rect,
+  name: 'fifo',
+}
+// stock 控件
+let stock = {
+  ...rect,
+  name: 'stock',
+}
 let group = {
   ...base,
   name: '群组'
@@ -89,4 +114,9 @@ export {
   line,
   capacity,
   process,
+  pps,
+  connector,
+  customer,
+  fifo,
+  stock,
 }


### PR DESCRIPTION
## Summary
- add process-like components in rect config
- clean up event bus file
- add all image-based components to the navigation
- unify process rendering logic with image map

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686770e76cec8322a5e5600f26b2d6f4